### PR TITLE
Indent list items by 4 spaces not 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function hr(inputHrStr) {
 
 function tab(size) {
   size = size || 4;
-  return (new Array(size)).join(' ');
+  return (new Array(size + 1)).join(' ');
 }
 
 function indentify(text) {

--- a/tests.js
+++ b/tests.js
@@ -50,9 +50,15 @@ describe('Renderer', function () {
       'This < is "foo". it\'s a & string';
 
     var expected = '# This < is "foo". it\'s a & string\n\n' +
-      '   This < is "foo". it\'s a & string\n\n' +
+      '    This < is "foo". it\'s a & string\n\n' +
       'This < is "foo". it\'s a & string\n' +
       'This < is "foo". it\'s a & string';
     assert.equal(marked(text).trim(), expected);
+  });
+
+  it('list items should be indented 4 spaces by default', function () {
+    var text = '* List item';
+    var expected = '    * List item\n\n'; // 4 leading spaces
+    assert.equal(marked(text), expected);
   });
 });


### PR DESCRIPTION
Fixes a minor issue where `tab()` defaults to returning 3 spaces not 4