### PR TITLE
Upgrade cardinal.js to v0.5.0 for ES6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "marked": "^0.3.2"
   },
   "dependencies": {
-    "cardinal": "^0.4.4",
+    "cardinal": "^0.5.0",
     "chalk": "^0.5.1",
     "cli-table": "^0.3.0",
     "node.extend": "^1.0.10"


### PR DESCRIPTION
This PR bumps the version of cardinal.js to [v0.5.0](https://github.com/thlorenz/cardinal/releases/tag/v0.5.0) to provide ES6 syntax highlighting support.

Ran tests on node.js v0.12.0
![screen shot 2015-03-04 at 11 06 01 am](https://cloud.githubusercontent.com/assets/324797/6490926/935fa402-c25e-11e4-9c29-8d8d0f1b6ad8.png)


Thanks!