### PR TITLE
Disable cardinal if chalk is not enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,13 @@ var assign = require('lodash.assign');
 var cardinal = require('cardinal');
 var emoji = require('node-emoji');
 
+if (!chalk.enabled) {
+  cardinal = {
+    highlight: function (code) {
+      return code;
+    }
+  };
+}
 
 var TABLE_CELL_SPLIT = '^*||*^';
 var TABLE_ROW_WRAP = '*|*|*|*';


### PR DESCRIPTION
`cardinal` does not use `chalk` internally and is not aware if [`chalk` turns itself off][supports-color] because of stdout redirection, command line flags or other reasons.

This makes the output achromatic, but with colored code blocks which is weird.

This patch fixes it by turning off `cardinal` if `chalk` is disabled.

[supports-color]: https://github.com/chalk/supports-color/blob/master/index.js