### PR TITLE
Add 'tab' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ var defaultOptions = {
   // Should it prefix headers?
   showSectionPrefix: true,
 
-  // Wheter or not to undo marked escaping
+  // Whether or not to undo marked escaping
   // of enitities (" -> &quot; etc)
   unescape: true,
 
@@ -105,7 +105,11 @@ var defaultOptions = {
   emoji: true,
 
   // Options passed to cli-table
-  tableOptions: {}
+  tableOptions: {},
+
+  // The size of tabs, in spaces
+  // or the replacement for spaces (only tabs supported)
+  tab: 3
 };
 ```
 

--- a/tests/options.js
+++ b/tests/options.js
@@ -1,5 +1,6 @@
 
 var assert = require('assert');
+var assign = require('lodash.assign');
 var Renderer = require('../');
 var marked = require('marked');
 
@@ -31,6 +32,40 @@ describe('Options', function () {
     assert.notEqual(marked(markdownText, {
       renderer: r
     }).indexOf(':emoji:'), -1);
+  });
+
+  it('should change tabs by space size', function () {
+    var options = assign({}, defaultOptions, { tab: 4 });
+    var r = new Renderer(options);
+
+    var blockquoteText = '> Blockquote'
+    assert.equal(
+      marked(blockquoteText, { renderer: r }),
+      '\n    Blockquote\n\n'
+    );
+
+    var listText = '* List Item'
+    assert.equal(
+      marked(listText, { renderer: r }),
+      '\n     * List Item\n\n'
+    );
+  });
+
+  it('should change tabs by allowed characters', function () {
+    var options = assign({}, defaultOptions, { tab: '\t' });
+    var r = new Renderer(options);
+
+    var blockquoteText = '> Blockquote'
+    assert.equal(
+      marked(blockquoteText, { renderer: r }),
+      '\n\tBlockquote\n\n'
+    );
+
+    var listText = '* List Item'
+    assert.equal(
+      marked(listText, { renderer: r }),
+      '\n\t * List Item\n\n'
+    );
   });
 
 });


### PR DESCRIPTION
Hi there!

One of the maintainers on [tslide/tslide][tslide] is trying to add this renderer to the project, but ran into an [issue][tslide17] with the size of tabs changing expecting behaviour. So, thought I'd throw this PR out to add an option to change the default tab fixture (which I thought was 4, but was actually 3!).

I was going to add the option to require numbers to specify the number of spaces, but then you can't use a \t char in place of spaces (possible case), so instead it can currently take any arbitrary string.

Let me know what you think of the PR, cheers!

[tslide]: https://github.com/tslide/tslide
[tslide17]: https://github.com/tslide/tslide/pull/17