### PR TITLE
Fix newlines consistency, list item trims and overriding list rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ var defaultOptions = {
   link: chalk.blue,
   href: chalk.blue.underline,
 
+  // Formats the bulletpoints and numbers for lists
+  list: function (body, ordered) {/* ... */},
+
   // Reflow and print-out width
   width: 80, // only applicable when reflow is true
   reflowText: false,

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ var defaultOptions = {
   firstHeading: chalk.magenta.underline.bold,
   hr: chalk.reset,
   listitem: chalk.reset,
+  list: list,
   table: chalk.reset,
   paragraph: chalk.reset,
   strong: chalk.bold,
@@ -45,7 +46,7 @@ var defaultOptions = {
   width: 80,
   showSectionPrefix: true,
   reflowText: false,
-  tab: 3,
+  tab: 4,
   tableOptions: {}
 };
 
@@ -77,11 +78,14 @@ Renderer.prototype.text = function (text) {
 };
 
 Renderer.prototype.code = function(code, lang, escaped) {
-  return '\n' + indentify(highlight(code, lang, this.o, this.highlightOptions), this.tab) + '\n\n';
+  return section(indentify(
+    this.tab,
+    highlight(code, lang, this.o, this.highlightOptions)
+  ));
 };
 
 Renderer.prototype.blockquote = function(quote) {
-  return '\n' + this.o.blockquote(indentify(quote.trim(), this.tab)) + '\n\n';
+  return section(this.o.blockquote(indentify(this.tab, quote.trim())));
 };
 
 Renderer.prototype.html = function(html) {
@@ -97,26 +101,23 @@ Renderer.prototype.heading = function(text, level, raw) {
   if (this.o.reflowText) {
     text = reflowText(text, this.o.width, this.options.gfm);
   }
-  if (level === 1) {
-    return this.o.firstHeading(text) + '\n';
-  }
-  return this.o.heading(text) + '\n';
+  return section(level === 1 ? this.o.firstHeading(text) : this.o.heading(text));
 };
 
 Renderer.prototype.hr = function() {
-  return this.o.hr(hr('-', this.o.reflowText && this.o.width)) + '\n';
+  return section(this.o.hr(hr('-', this.o.reflowText && this.o.width)));
 };
 
 Renderer.prototype.list = function(body, ordered) {
-  body = indentLines(this.o.listitem(body), this.tab);
-  if (!ordered) return body;
-  return changeToOrdered(body);
+  body = this.o.list(body, ordered)
+  return section(indentLines(this.tab, body));
 };
 
 Renderer.prototype.listitem = function(text) {
-  var isNested = ~text.indexOf('\n');
+  var transform = compose(this.o.listitem, this.transform);
+  var isNested = text.indexOf('\n') !== -1;
   if (isNested) text = text.trim();
-  return '\n * ' + this.transform(text);
+  return '\n' + transform(text);
 };
 
 Renderer.prototype.paragraph = function(text) {
@@ -125,7 +126,7 @@ Renderer.prototype.paragraph = function(text) {
   if (this.o.reflowText) {
     text = reflowText(text, this.o.width, this.options.gfm);
   }
-  return text + '\n\n';
+  return section(text);
 };
 
 Renderer.prototype.table = function(header, body) {
@@ -136,7 +137,7 @@ Renderer.prototype.table = function(header, body) {
   generateTableRow(body, this.transform).forEach(function (row) {
     table.push(row);
   });
-  return this.o.table(table.toString()) + '\n\n';
+  return section(this.o.table(table.toString()));
 };
 
 Renderer.prototype.tablerow = function(content) {
@@ -233,16 +234,45 @@ function reflowText (text, width, gfm) {
   return reflowed.join('\n');
 }
 
-function indentLines (text, tab) {
-  return text.replace(/\n/g, '\n' + tab) + '\n\n';
+function indentLines (indent, text) {
+  return text.replace(/(^|\n)(.+)/g, '$1' + indent + '$2');
 }
 
-function changeToOrdered(text) {
-  var i = 1;
-  return text.split('\n').reduce(function (acc, line) {
-    if (!line) return '\n' + acc;
-    return acc + line.replace(/(\s*)\*/, '$1' + (i++) + '.') + '\n';
-  });
+function indentify(indent, text) {
+  if (!text) return text;
+  return indent + text.split('\n').join('\n' + indent);
+}
+
+function bulletPointLine (line) {
+  return line.match(/^\s*\*/) ? line : '* ' + line;
+}
+
+function bulletPointLines (lines) {
+  return lines.split('\n')
+    .filter(identity)
+    .map(bulletPointLine)
+    .join('\n');
+}
+
+function numberedLine (line, num) {
+  return line.match(/^\s*\d+\./) ? line : (num+1) + '. ' + line;
+}
+
+function numberedLines (lines) {
+  return lines.split('\n')
+    .filter(identity)
+    .map(numberedLine)
+    .join('\n');
+}
+
+function list(body, ordered) {
+  body = body.trim();
+  body = ordered ? numberedLines(body) : bulletPointLines(body);
+  return body;
+}
+
+function section (text) {
+  return '\n' + text + '\n';
 }
 
 function highlight(code, lang, opts, hightlightOpts) {
@@ -277,11 +307,6 @@ function hr(inputHrStr, length) {
 
 function undoColon (str) {
   return str.replace(COLON_REPLACER_REGEXP, ':');
-}
-
-function indentify(text, tab) {
-  if (!text) return text;
-  return tab + text.split('\n').join('\n' + tab);
 }
 
 function generateTableRow(text, escape) {

--- a/index.js
+++ b/index.js
@@ -243,8 +243,10 @@ function indentify(indent, text) {
   return indent + text.split('\n').join('\n' + indent);
 }
 
+var listItemPoint = /^\s*(\*|\d+\.)/;
+
 function bulletPointLine (line) {
-  return line.match(/^\s*\*/) ? line : '* ' + line;
+  return line.match(listItemPoint) ? line : '* ' + line;
 }
 
 function bulletPointLines (lines) {
@@ -255,7 +257,7 @@ function bulletPointLines (lines) {
 }
 
 function numberedLine (line, num) {
-  return line.match(/^\s*\d+\./) ? line : (num+1) + '. ' + line;
+  return line.match(listItemPoint) ? line : (num+1) + '. ' + line;
 }
 
 function numberedLines (lines) {

--- a/tests/e2e.js
+++ b/tests/e2e.js
@@ -1,0 +1,49 @@
+
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+var Renderer = require('../');
+var marked = require('marked');
+
+
+var identity = function (o) {
+  return o;
+};
+
+function stripTermEsc (str) {
+  return str.replace(/\u001b\[\d{1,2}m/g, "");
+}
+
+function getFixtureFile (fileName) {
+  return fs.readFileSync(
+    path.resolve(__dirname, 'fixtures/', fileName),
+    { encoding: 'utf8' }
+  );
+}
+
+var opts = [
+  'code', 'blockquote', 'html', 'heading',
+  'firstHeading', 'hr', 'listitem', 'table',
+  'paragraph', 'strong', 'em', 'codespan',
+  'del', 'link', 'href'
+];
+
+var defaultOptions = {};
+opts.forEach(function (opt) {
+  defaultOptions[opt] = identity;
+});
+
+function markup(str) {
+  var r = new Renderer(defaultOptions);
+  return stripTermEsc(marked(str, { renderer: r }));
+}
+
+describe('e2', function () {
+
+  it('should render a document full of different supported syntax', function () {
+    const actual = markup(getFixtureFile('e2e.md'));
+    const expected = getFixtureFile('e2e.result.txt');
+    assert.equal(actual, expected);
+  });
+
+});

--- a/tests/fixtures/e2e.md
+++ b/tests/fixtures/e2e.md
@@ -1,0 +1,60 @@
+It's very easy to make some words **bold** and other words *italic* with Markdown. You can even [link to Google!](http://google.com)
+
+Sometimes you want numbered lists:
+
+1. One
+2. Two
+3. Three
+
+Sometimes you want bullet points:
+
+* Start a line with a star
+* Profit!
+
+Alternatively,
+
+- Dashes work just as well
+- And if you have sub points, put two spaces before the dash or star:
+  - Like this
+  - And this
+
+But also,
+
+1. And numbered lists
+  1. Can also have
+  2. Several sub points
+
+# Structured documents
+
+Sometimes it's useful to have different levels of headings to structure your documents. Start lines with a `#` to create headings. Multiple `##` in a row denote smaller heading sizes.
+
+### This is a third-tier heading
+
+You can use one `#` all the way up to `######` six for different heading sizes.
+
+If you'd like to quote someone, use the > character before the line:
+
+> Coffee. The finest organic suspension ever devised... I beat the Borg with it.
+> \- Captain Janeway
+
+There are many different ways to style code with GitHub's markdown. If you have inline code blocks, wrap them in backticks: `var example = true`.  If you've got a longer block of code, you can indent with four spaces:
+
+    if (isAwesome){
+      return true
+    }
+
+GitHub also supports something called code fencing, which allows for multiple lines without indentation:
+
+```
+if (isAwesome){
+  return true
+}
+```
+
+And if you'd like to use syntax highlighting, include the language:
+
+```javascript
+if (isAwesome){
+  return true
+}
+```

--- a/tests/fixtures/e2e.result.txt
+++ b/tests/fixtures/e2e.result.txt
@@ -1,4 +1,3 @@
-
 It's very easy to make some words bold and other words italic with Markdown. You can even link to Google! (http://google.com)
 
 Sometimes you want numbered lists:
@@ -55,3 +54,4 @@ And if you'd like to use syntax highlighting, include the language:
     if (isAwesome){
       return true
     }
+

--- a/tests/fixtures/e2e.result.txt
+++ b/tests/fixtures/e2e.result.txt
@@ -1,0 +1,57 @@
+
+It's very easy to make some words bold and other words italic with Markdown. You can even link to Google! (http://google.com)
+
+Sometimes you want numbered lists:
+
+    1. One
+    2. Two
+    3. Three
+
+Sometimes you want bullet points:
+
+    * Start a line with a star
+    * Profit!
+
+Alternatively,
+
+    * Dashes work just as well
+    * And if you have sub points, put two spaces before the dash or star:
+        * Like this
+        * And this
+
+But also,
+
+    1. And numbered lists
+        1. Can also have
+        2. Several sub points
+
+# Structured documents
+
+Sometimes it's useful to have different levels of headings to structure your documents. Start lines with a # to create headings. Multiple ## in a row denote smaller heading sizes.
+
+### This is a third-tier heading
+
+You can use one # all the way up to ###### six for different heading sizes.
+
+If you'd like to quote someone, use the > character before the line:
+
+    Coffee. The finest organic suspension ever devised... I beat the Borg with it.
+    - Captain Janeway
+
+There are many different ways to style code with GitHub's markdown. If you have inline code blocks, wrap them in backticks: var example = true.  If you've got a longer block of code, you can indent with four spaces:
+
+    if (isAwesome){
+      return true
+    }
+
+GitHub also supports something called code fencing, which allows for multiple lines without indentation:
+
+    if (isAwesome){
+      return true
+    }
+
+And if you'd like to use syntax highlighting, include the language:
+
+    if (isAwesome){
+      return true
+    }

--- a/tests/options.js
+++ b/tests/options.js
@@ -41,13 +41,13 @@ describe('Options', function () {
     var blockquoteText = '> Blockquote'
     assert.equal(
       marked(blockquoteText, { renderer: r }),
-      '\n    Blockquote\n\n'
+      '\n    Blockquote\n'
     );
 
     var listText = '* List Item'
     assert.equal(
       marked(listText, { renderer: r }),
-      '\n     * List Item\n\n'
+      '\n    * List Item\n'
     );
   });
 
@@ -58,13 +58,13 @@ describe('Options', function () {
     var blockquoteText = '> Blockquote'
     assert.equal(
       marked(blockquoteText, { renderer: r }),
-      '\n   Blockquote\n\n'
+      '\n    Blockquote\n'
     );
 
     var listText = '* List Item'
     assert.equal(
       marked(listText, { renderer: r }),
-      '\n    * List Item\n\n'
+      '\n    * List Item\n'
     );
   });
 
@@ -75,13 +75,13 @@ describe('Options', function () {
     var blockquoteText = '> Blockquote'
     assert.equal(
       marked(blockquoteText, { renderer: r }),
-      '\n\tBlockquote\n\n'
+      '\n\tBlockquote\n'
     );
 
     var listText = '* List Item'
     assert.equal(
       marked(listText, { renderer: r }),
-      '\n\t * List Item\n\n'
+      '\n\t* List Item\n'
     );
   });
 
@@ -92,13 +92,13 @@ describe('Options', function () {
     var blockquoteText = '> Blockquote'
     assert.equal(
       marked(blockquoteText, { renderer: r }),
-      '\n\t\tBlockquote\n\n'
+      '\n\t\tBlockquote\n'
     );
 
     var listText = '* List Item'
     assert.equal(
       marked(listText, { renderer: r }),
-      '\n\t\t * List Item\n\n'
+      '\n\t\t* List Item\n'
     );
   });
 

--- a/tests/options.js
+++ b/tests/options.js
@@ -41,13 +41,13 @@ describe('Options', function () {
     var blockquoteText = '> Blockquote'
     assert.equal(
       marked(blockquoteText, { renderer: r }),
-      '\n    Blockquote\n'
+      '    Blockquote\n\n'
     );
 
     var listText = '* List Item'
     assert.equal(
       marked(listText, { renderer: r }),
-      '\n    * List Item\n'
+      '    * List Item\n\n'
     );
   });
 
@@ -58,13 +58,13 @@ describe('Options', function () {
     var blockquoteText = '> Blockquote'
     assert.equal(
       marked(blockquoteText, { renderer: r }),
-      '\n    Blockquote\n'
+      '    Blockquote\n\n'
     );
 
     var listText = '* List Item'
     assert.equal(
       marked(listText, { renderer: r }),
-      '\n    * List Item\n'
+      '    * List Item\n\n'
     );
   });
 
@@ -75,13 +75,13 @@ describe('Options', function () {
     var blockquoteText = '> Blockquote'
     assert.equal(
       marked(blockquoteText, { renderer: r }),
-      '\n\tBlockquote\n'
+      '\tBlockquote\n\n'
     );
 
     var listText = '* List Item'
     assert.equal(
       marked(listText, { renderer: r }),
-      '\n\t* List Item\n'
+      '\t* List Item\n\n'
     );
   });
 
@@ -92,13 +92,13 @@ describe('Options', function () {
     var blockquoteText = '> Blockquote'
     assert.equal(
       marked(blockquoteText, { renderer: r }),
-      '\n\t\tBlockquote\n'
+      '\t\tBlockquote\n\n'
     );
 
     var listText = '* List Item'
     assert.equal(
       marked(listText, { renderer: r }),
-      '\n\t\t* List Item\n'
+      '\t\t* List Item\n\n'
     );
   });
 

--- a/tests/usage.js
+++ b/tests/usage.js
@@ -87,7 +87,7 @@ describe('Renderer', function () {
       'This < is "foo". it\'s a & string';
 
     var expected = '# This < is "foo". it\'s a & string\n\n' +
-      '   This < is "foo". it\'s a & string\n\n' +
+      '    This < is "foo". it\'s a & string\n\n' +
       'This < is "foo". it\'s a & string\n' +
       'This < is "foo". it\'s a & string';
     assert.equal(marked(text, markedOptions).trim(), expected);
@@ -119,32 +119,55 @@ describe('Renderer', function () {
 
   it('should reflow paragraph', function () {
     text = 'Now is the time\n',
-    expected = 'Now is the\ntime\n\n';
+    expected = '\nNow is the\ntime\n';
     assert.equal(markup(text), expected);
   });
 
   it('should nuke section header', function () {
     text = '# Contents\n',
-    expected = 'Contents\n';
+    expected = '\nContents\n';
     assert.equal(markup(text), expected);
   });
 
   it('should reflow and nuke section header', function () {
     text = '# Now is the time\n',
-    expected = 'Now is the\ntime\n';
+    expected = '\nNow is the\ntime\n';
     assert.equal(markup(text), expected);
   });
 
   it('should preserve line breaks (non gfm)', function () {
     text = 'Now  \nis    \nthe<br />time\n',
-    expected = 'Now\nis\nthe<br\n/>time\n\n';
+    expected = '\nNow\nis\nthe<br\n/>time\n';
     assert.equal(markup(text, false), expected);
   });
 
   it('should preserve line breaks (gfm)', function () {
     text = 'Now  \nis    \nthe<br />time\n',
-    expected = 'Now\nis\nthe\ntime\n\n';
+    expected = '\nNow\nis\nthe\ntime\n';
     assert.equal(markup(text, true), expected);
+  });
+
+  it('should render ordered and unordered list with same newlines', function () {
+    var ul = '* ul item\n' +
+    '* ul item';
+    var ol = '1. ol item\n' +
+    '2. ol item';
+    var before = '\n';
+    var after = '\n';
+
+    assert.equal(markup(ul),
+      before +
+      '    * ul item\n' +
+      '    * ul item' +
+      after
+    );
+
+    assert.equal(markup(ol),
+      before +
+      '    1. ol item\n' +
+      '    2. ol item' +
+      after
+    );
   });
 
 });

--- a/tests/usage.js
+++ b/tests/usage.js
@@ -170,4 +170,45 @@ describe('Renderer', function () {
     );
   });
 
+  it('should render nested lists', function () {
+    var ul = '* ul item\n' +
+    '    * ul item';
+    var ol = '1. ol item\n' +
+    '    1. ol item';
+    var olul = '1. ol item\n' +
+    '    * ul item';
+    var ulol = '* ul item\n' +
+    '    1. ol item';
+    var before = '\n';
+    var after = '\n';
+
+    assert.equal(markup(ul),
+      before +
+      '    * ul item\n' +
+      '        * ul item' +
+      after
+    );
+
+    assert.equal(markup(ol),
+      before +
+      '    1. ol item\n' +
+      '        1. ol item' +
+      after
+    );
+
+    assert.equal(markup(olul),
+      before +
+      '    1. ol item\n' +
+      '        * ul item' +
+      after
+    );
+
+    assert.equal(markup(ulol),
+      before +
+      '    * ul item\n' +
+      '        1. ol item' +
+      after
+    );
+  });
+
 });

--- a/tests/usage.js
+++ b/tests/usage.js
@@ -119,31 +119,31 @@ describe('Renderer', function () {
 
   it('should reflow paragraph', function () {
     text = 'Now is the time\n',
-    expected = '\nNow is the\ntime\n';
+    expected = 'Now is the\ntime\n\n';
     assert.equal(markup(text), expected);
   });
 
   it('should nuke section header', function () {
     text = '# Contents\n',
-    expected = '\nContents\n';
+    expected = 'Contents\n\n';
     assert.equal(markup(text), expected);
   });
 
   it('should reflow and nuke section header', function () {
     text = '# Now is the time\n',
-    expected = '\nNow is the\ntime\n';
+    expected = 'Now is the\ntime\n\n';
     assert.equal(markup(text), expected);
   });
 
   it('should preserve line breaks (non gfm)', function () {
     text = 'Now  \nis    \nthe<br />time\n',
-    expected = '\nNow\nis\nthe<br\n/>time\n';
+    expected = 'Now\nis\nthe<br\n/>time\n\n';
     assert.equal(markup(text, false), expected);
   });
 
   it('should preserve line breaks (gfm)', function () {
     text = 'Now  \nis    \nthe<br />time\n',
-    expected = '\nNow\nis\nthe\ntime\n';
+    expected = 'Now\nis\nthe\ntime\n\n';
     assert.equal(markup(text, true), expected);
   });
 
@@ -152,8 +152,8 @@ describe('Renderer', function () {
     '* ul item';
     var ol = '1. ol item\n' +
     '2. ol item';
-    var before = '\n';
-    var after = '\n';
+    var before = '';
+    var after = '\n\n';
 
     assert.equal(markup(ul),
       before +
@@ -179,8 +179,8 @@ describe('Renderer', function () {
     '    * ul item';
     var ulol = '* ul item\n' +
     '    1. ol item';
-    var before = '\n';
-    var after = '\n';
+    var before = '';
+    var after = '\n\n';
 
     assert.equal(markup(ul),
       before +


### PR DESCRIPTION
Hello again,

Following things were fixed, and that could mean this is a major semver change:
- Block sections (paragraph, code, blockquote, list, headings) would sometimes have different vertical padding (new lines)
- There was a space before list items
- Missing distinction between rendering lists and list items, overridable through options
  - `listitem` is still just a chalk reset
  - `list` _(new option)_ takes the `function (body, ordered)` signature. it is responsible for attaching points onto list item

I've introduced a weird padding behaviour; _there will always be a newline at the start of the output_.

I needed to introduce it to make consistent vertical padding AND make sure that nested lists work. I don't really want it there, but couldn't think of a way to get rid of it.

I'll need you to weigh in with this, concerning the newline-at-the-start-of-output and also how these changes may require a major semver change due to how old expected behaviours have changed.
