### PR TITLE
No longer bullet every line of multi-line list items

### DIFF
--- a/tests/fixtures/e2e.md
+++ b/tests/fixtures/e2e.md
@@ -14,13 +14,15 @@ Sometimes you want bullet points:
 Alternatively,
 
 - Dashes work just as well
-- And if you have sub points, put two spaces before the dash or star:
+- And if you have sub points,
+  put two spaces before the dash or star:
   - Like this
   - And this
 
 But also,
 
-1. And numbered lists
+1. And not to forget
+   numbered lists
   1. Can also have
   2. Several sub points
 

--- a/tests/fixtures/e2e.result.txt
+++ b/tests/fixtures/e2e.result.txt
@@ -14,13 +14,15 @@ Sometimes you want bullet points:
 Alternatively,
 
     * Dashes work just as well
-    * And if you have sub points, put two spaces before the dash or star:
+    * And if you have sub points,
+      put two spaces before the dash or star:
         * Like this
         * And this
 
 But also,
 
-    1. And numbered lists
+    1. And not to forget
+       numbered lists
         1. Can also have
         2. Several sub points
 


### PR DESCRIPTION
Intended to resolve #32.  This adjusts the output of list items so that multi-line list items have aligned lines rather than bulleted lines.  Here's an example to illustrate,

#### Input
```
Alternatively,

- Dashes work just as well
- And if you have sub points,
  put two spaces before the dash or star:
  - Like this
  - And this

But also,

1. And not to forget
   numbered lists
  1. Can also have
  2. Several sub points
```

#### Output Before
```
Alternatively,

    * Dashes work just as well
    * And if you have sub points,
    * put two spaces before the dash or star:
        * Like this
        * And this

But also,

    1. And not to forget
    2. numbered lists
        1. Can also have
        2. Several sub points
```

#### Output After
```
Alternatively,

    * Dashes work just as well
    * And if you have sub points,
      put two spaces before the dash or star:
        * Like this
        * And this

But also,

    1. And not to forget
       numbered lists
        1. Can also have
        2. Several sub points
```