### PR TITLE
Use `Object.assign` over `lodash.assign`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var chalk = require('chalk');
 var Table = require('cli-table');
-var assign = require('lodash.assign');
 var cardinal = require('cardinal');
 var emoji = require('node-emoji');
 
@@ -51,7 +50,7 @@ var defaultOptions = {
 };
 
 function Renderer(options, highlightOptions) {
-  this.o = assign({}, defaultOptions, options);
+  this.o = Object.assign({}, defaultOptions, options);
   this.tab = sanitizeTab(this.o.tab, defaultOptions.tab);
   this.tableSettings = this.o.tableOptions;
   this.emoji = this.o.emoji ? insertEmojis : identity;
@@ -136,7 +135,7 @@ Renderer.prototype.paragraph = function(text) {
 };
 
 Renderer.prototype.table = function(header, body) {
-  var table = new Table(assign({}, {
+  var table = new Table(Object.assign({}, {
       head: generateTableRow(header)[0]
   }, this.tableSettings));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "marked-terminal",
-  "version": "3.0.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -174,11 +174,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.toarray": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "cardinal": "^2.1.1",
     "chalk": "^2.4.1",
     "cli-table": "^0.3.1",
-    "lodash.assign": "^4.2.0",
     "node-emoji": "^1.4.1"
   },
   "directories": {

--- a/tests/options.js
+++ b/tests/options.js
@@ -1,6 +1,5 @@
 
 var assert = require('assert');
-var assign = require('lodash.assign');
 var Renderer = require('../');
 var marked = require('marked');
 
@@ -35,7 +34,7 @@ describe('Options', function () {
   });
 
   it('should change tabs by space size', function () {
-    var options = assign({}, defaultOptions, { tab: 4 });
+    var options = Object.assign({}, defaultOptions, { tab: 4 });
     var r = new Renderer(options);
 
     var blockquoteText = '> Blockquote'
@@ -52,7 +51,7 @@ describe('Options', function () {
   });
 
   it('should use default tabs if passing not supported string', function () {
-    var options = assign({}, defaultOptions, { tab: 'dsakdskajhdsa' });
+    var options = Object.assign({}, defaultOptions, { tab: 'dsakdskajhdsa' });
     var r = new Renderer(options);
 
     var blockquoteText = '> Blockquote'
@@ -69,7 +68,7 @@ describe('Options', function () {
   });
 
   it('should change tabs by allowed characters', function () {
-    var options = assign({}, defaultOptions, { tab: '\t' });
+    var options = Object.assign({}, defaultOptions, { tab: '\t' });
     var r = new Renderer(options);
 
     var blockquoteText = '> Blockquote'
@@ -86,7 +85,7 @@ describe('Options', function () {
   });
 
   it('should support mulitple tab characters', function () {
-    var options = assign({}, defaultOptions, { tab: '\t\t' });
+    var options = Object.assign({}, defaultOptions, { tab: '\t\t' });
     var r = new Renderer(options);
 
     var blockquoteText = '> Blockquote'


### PR DESCRIPTION
It's supported by all the versions of `node` in the `.travis.yml`.  The `chalk` dependency requires `node>=4`, anyway.