### PR TITLE
update marked dev and peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "marked-terminal",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -186,9 +186,9 @@
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
     },
     "marked": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.0.tgz",
-      "integrity": "sha512-HduzIW2xApSXKXJSpCipSxKyvMbwRRa/TwMbepmlZziKdH8548WSoDP4SxzulEKjlo8BE39l+2fwJZuRKOln6g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
       "dev": true
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Mikael Brevik",
   "license": "MIT",
   "peerDependencies": {
-    "marked": "^0.4.0 || ^0.5.0 || ^0.6.0"
+    "marked": "^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0"
   },
   "dependencies": {
     "ansi-escapes": "^3.1.0",
@@ -33,7 +33,7 @@
     "example": "example"
   },
   "devDependencies": {
-    "marked": "^0.6.0",
+    "marked": "^0.7.0",
     "mocha": "^5.2.0"
   },
   "repository": {


### PR DESCRIPTION
`marked` has a new `0.x` minor version (due to https://www.npmjs.com/advisories/1076).

This:
* updates the peer dependency to also accept `^0.7.0`
* updates the dev dependency to `^0.7.0`