### PR TITLE
Add "Related" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,7 @@ readme there to see what options to pass.
 
 
 See [more examples](./example/)
+
+## Related
+
+- [ink-markdown](https://github.com/cameronhunter/ink-markdown) - Markdown component for Ink


### PR DESCRIPTION
Linking to [`ink-markdown`](https://github.com/cameronhunter/ink-markdown) in README.

`ink-markdown` is a thin wrapper around `marked-terminal` allowing it to be used as an Ink React component.