### PR TITLE
Update/Support for marked v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "marked-terminal",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -576,9 +576,9 @@
       }
     },
     "marked": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
-      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
       "dev": true
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Mikael Brevik",
   "license": "MIT",
   "peerDependencies": {
-    "marked": "^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0"
+    "marked": "^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^1.0.0"
   },
   "dependencies": {
     "ansi-escapes": "^4.3.0",
@@ -33,7 +33,7 @@
     "example": "example"
   },
   "devDependencies": {
-    "marked": "^0.8.0",
+    "marked": "^1.0.0",
     "mocha": "^7.0.0"
   },
   "repository": {

--- a/tests/usage.js
+++ b/tests/usage.js
@@ -166,7 +166,7 @@ describe('Renderer', function() {
 
   it('should preserve line breaks (non gfm)', function() {
     (text = 'Now  \nis    \nthe<br />time\n'),
-      (expected = 'Now\nis\nthe<br\n/>time\n\n');
+      (expected = "Now\nis\nthe<br />\ntime\n\n");
     assert.equal(markup(text, false), expected);
   });
 

--- a/tests/usage.js
+++ b/tests/usage.js
@@ -166,7 +166,7 @@ describe('Renderer', function() {
 
   it('should preserve line breaks (non gfm)', function() {
     (text = 'Now  \nis    \nthe<br />time\n'),
-      (expected = "Now\nis\nthe<br />\ntime\n\n");
+      (expected = 'Now\nis\nthe<br />\ntime\n\n');
     assert.equal(markup(text, false), expected);
   });
 


### PR DESCRIPTION
Supports the lates marked version.

I'm not fully sure about the change for the test, the previously expected value confuses me a bit with the line break inside the br-tag