### PR TITLE
Fix peerDependency install warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "marked-terminal",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.1",
@@ -16,11 +16,11 @@
         "supports-hyperlinks": "^2.1.0"
       },
       "devDependencies": {
-        "marked": "^2.0.1",
+        "marked": "^3.0.4",
         "mocha": "^8.2.1"
       },
       "peerDependencies": {
-        "marked": "^1.0.0 || ^2.0.0"
+        "marked": ">=3"
       }
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -630,15 +630,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
-      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.4.tgz",
+      "integrity": "sha512-jBo8AOayNaEcvBhNobg6/BLhdsK3NvnKWJg33MAAPbvTWiG4QBn9gpW1+7RssrKu4K1dKlN+0goVQwV41xEfOA==",
       "dev": true,
       "bin": {
         "marked": "bin/marked"
       },
       "engines": {
-        "node": ">= 8.16.2"
+        "node": ">= 12"
       }
     },
     "node_modules/minimatch": {
@@ -1726,9 +1726,9 @@
       }
     },
     "marked": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
-      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.4.tgz",
+      "integrity": "sha512-jBo8AOayNaEcvBhNobg6/BLhdsK3NvnKWJg33MAAPbvTWiG4QBn9gpW1+7RssrKu4K1dKlN+0goVQwV41xEfOA==",
       "dev": true
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Mikael Brevik",
   "license": "MIT",
   "peerDependencies": {
-    "marked": "^1.0.0 || ^2.0.0"
+    "marked": ">=3"
   },
   "dependencies": {
     "ansi-escapes": "^4.3.1",
@@ -33,7 +33,7 @@
     "example": "example"
   },
   "devDependencies": {
-    "marked": "^2.0.1",
+    "marked": "^3.0.4",
     "mocha": "^8.2.1"
   },
   "repository": {


### PR DESCRIPTION
Fix warning.

```warning " > marked-terminal@4.2.0" has incorrect peer dependency "marked@^1.0.0 || ^2.0.0".```