### PR TITLE
Fix required Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=14.13.1 || >=16.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
The CommonJS built depends on `node:process` that was introduced only in v16:

![image](https://user-images.githubusercontent.com/52201/172511187-0f1a212f-6bea-44dd-b452-88e66be560b6.png)

And it breaks on Node.js v15:

![image](https://user-images.githubusercontent.com/52201/172511417-374ecaa5-0873-46e9-b350-b92dfda6cbeb.png)

...and also with Jest (26.6.3) running on v16:

![image](https://user-images.githubusercontent.com/52201/172511529-94ffe9b1-2a9a-4e2b-b395-a5ce8095bb98.png)
