### PR TITLE
Update peerDependecy `marked` with major releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "Mikael Brevik",
   "license": "MIT",
   "peerDependencies": {
-    "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+    "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
   },
   "dependencies": {
     "ansi-escapes": "^6.2.0",


### PR DESCRIPTION
In this PR:

- [x] Updates `peerDependencies` to include marked major version 6, 7, 8 and 9. 