### PR TITLE
feat: add use extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,6 +231,41 @@ Renderer.prototype.image = function (href, title, text) {
 
 export default Renderer;
 
+export function markedTerminal(options, highlightOptions) {
+  const r = new Renderer(options, highlightOptions);
+
+  const funcs = [
+    'text',
+    'code',
+    'blockquote',
+    'html',
+    'heading',
+    'hr',
+    'list',
+    'listitem',
+    'checkbox',
+    'paragraph',
+    'table',
+    'tablerow',
+    'tablecell',
+    'strong',
+    'em',
+    'codespan',
+    'br',
+    'del',
+    'link',
+    'image',
+  ];
+
+  return funcs.reduce((extension, func) => {
+    extension.renderer[func] = function (...args) {
+      r.options = this.options;
+      return r[func](...args);
+    };
+    return extension;
+  }, {renderer: {}});
+}
+
 // Munge \n's and spaces in "text" so that the number of
 // characters between \n's is less than or equal to "width".
 function reflowText(text, width, gfm) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
-        "marked": "^5.0.2",
+        "cross-env": "^7.0.3",
+        "marked": "^9.0.3",
         "mocha": "^10.2.0",
         "rollup": "^3.21.7"
       },
@@ -396,6 +397,38 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -737,6 +770,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -811,15 +850,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-5.0.2.tgz",
-      "integrity": "sha512-TXksm9GwqXCRNbFUZmMtqNLvy3K2cQHuWmyBDLOrY1e6i9UvZpOTJXoz7fBjYkJkaUFzV9hBFxMuZSyQt8R6KQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.0.3.tgz",
+      "integrity": "sha512-pI/k4nzBG1PEq1J3XFEHxVvjicfjl8rgaMaqclouGSMPhk7Q3Ejb2ZRxx/ZQOcQ1909HzVoWCFYq6oLgtL4BpQ==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 16"
       }
     },
     "node_modules/minimatch": {
@@ -1005,6 +1044,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -1123,6 +1171,27 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -1212,6 +1281,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/workerpool": {
@@ -1579,6 +1663,26 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1825,6 +1929,12 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
     "js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1880,9 +1990,9 @@
       }
     },
     "marked": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-5.0.2.tgz",
-      "integrity": "sha512-TXksm9GwqXCRNbFUZmMtqNLvy3K2cQHuWmyBDLOrY1e6i9UvZpOTJXoz7fBjYkJkaUFzV9hBFxMuZSyQt8R6KQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.0.3.tgz",
+      "integrity": "sha512-pI/k4nzBG1PEq1J3XFEHxVvjicfjl8rgaMaqclouGSMPhk7Q3Ejb2ZRxx/ZQOcQ1909HzVoWCFYq6oLgtL4BpQ==",
       "dev": true
     },
     "minimatch": {
@@ -2023,6 +2133,12 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -2102,6 +2218,21 @@
         "randombytes": "^2.1.0"
       }
     },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2162,6 +2293,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.0.0.tgz",
       "integrity": "sha512-MINvUN5ug9u+0hJDzSZNSnuKXI8M4F5Yvb6SQZ2CYqe7SgKXKOosEcU5R7tRgo85I6eAVBbkVF7TCvB4AUK2xQ=="
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "workerpool": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "rollup -c",
     "prepack": "npm run build",
-    "test": "FORCE_HYPERLINK=0 mocha tests/*.js --reporter spec"
+    "test": "cross-env FORCE_HYPERLINK=0 mocha tests/*.js --reporter spec"
   },
   "files": [
     "index.js",
@@ -34,7 +34,7 @@
   "author": "Mikael Brevik",
   "license": "MIT",
   "peerDependencies": {
-    "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+    "marked": ">=1 <10"
   },
   "dependencies": {
     "ansi-escapes": "^6.2.0",
@@ -50,7 +50,8 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
-    "marked": "^5.0.2",
+    "cross-env": "^7.0.3",
+    "marked": "^9.0.3",
     "mocha": "^10.2.0",
     "rollup": "^3.21.7"
   },

--- a/tests/_marked.js
+++ b/tests/_marked.js
@@ -1,11 +1,19 @@
 import * as m from 'marked';
 
-if ('use' in m) {
-  // Test wrapper to handle v5 with breaking changes
-  m.use({
-    mangle: false,
-    headerIds: false
-  });
-}
+const marked = 'marked' in m ? m.marked : m.default;
 
-export default 'marked' in m ? m.marked : m.default;
+resetMarked();
+
+export default marked;
+
+export function resetMarked() {
+  marked.setOptions(marked.getDefaults());
+
+  if ('use' in marked) {
+    // Test wrapper to handle v5 with breaking changes
+    marked.use({
+      mangle: false,
+      headerIds: false
+    });
+  }
+}

--- a/tests/e2e.js
+++ b/tests/e2e.js
@@ -2,7 +2,7 @@ import { equal } from 'assert';
 import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import Renderer from '../index.js';
-import marked from './_marked.js';
+import marked, { resetMarked } from './_marked.js';
 import { fileURLToPath } from 'url';
 
 var identity = function (o) {
@@ -52,7 +52,7 @@ function markup(str) {
 
 describe('e2', function () {
   beforeEach(function () {
-    marked.setOptions(marked.getDefaults());
+    resetMarked();
   });
 
   it('should render a document full of different supported syntax', function () {

--- a/tests/markedTerminal-e2e.js
+++ b/tests/markedTerminal-e2e.js
@@ -2,7 +2,7 @@ import { equal } from 'assert';
 import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { markedTerminal } from '../index.js';
-import marked from './_marked.js';
+import marked, { resetMarked } from './_marked.js';
 import { fileURLToPath } from 'url';
 
 var identity = function (o) {
@@ -51,6 +51,10 @@ function markup(str) {
 }
 
 describe('e2', function () {
+  beforeEach(function () {
+    resetMarked();
+  });
+
   it('should render a document full of different supported syntax', function () {
     const actual = markup(getFixtureFile('e2e.md'));
     const expected = getFixtureFile('e2e.result.txt');

--- a/tests/markedTerminal-e2e.js
+++ b/tests/markedTerminal-e2e.js
@@ -1,7 +1,7 @@
 import { equal } from 'assert';
 import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
-import Renderer from '../index.js';
+import { markedTerminal } from '../index.js';
 import marked from './_marked.js';
 import { fileURLToPath } from 'url';
 
@@ -46,15 +46,11 @@ opts.forEach(function (opt) {
 });
 
 function markup(str) {
-  var r = new Renderer(defaultOptions);
-  return stripTermEsc(marked(str, { renderer: r }));
+  marked.use(markedTerminal(defaultOptions));
+  return stripTermEsc(marked(str));
 }
 
 describe('e2', function () {
-  beforeEach(function () {
-    marked.setOptions(marked.getDefaults());
-  });
-
   it('should render a document full of different supported syntax', function () {
     const actual = markup(getFixtureFile('e2e.md'));
     const expected = getFixtureFile('e2e.result.txt');

--- a/tests/markedTerminal-options.js
+++ b/tests/markedTerminal-options.js
@@ -1,5 +1,5 @@
 import { notEqual, equal } from 'assert';
-import Renderer from '../index.js';
+import { markedTerminal } from '../index.js';
 import marked from './_marked.js';
 
 var identity = function (o) {
@@ -32,65 +32,62 @@ opts.forEach(function (opt) {
 defaultOptions.emoji = false;
 
 describe('Options', function () {
-  var r = new Renderer(defaultOptions);
-
   beforeEach(function () {
     marked.setOptions(marked.getDefaults());
   });
 
   it('should not translate emojis', function () {
+    marked.use(markedTerminal(defaultOptions));
     var markdownText = 'Some :emoji:';
 
     notEqual(
-      marked(markdownText, {
-        renderer: r
-      }).indexOf(':emoji:'),
+      marked(markdownText).indexOf(':emoji:'),
       -1
     );
   });
 
   it('should change tabs by space size', function () {
     var options = Object.assign({}, defaultOptions, { tab: 4 });
-    var r = new Renderer(options);
+    marked.use(markedTerminal(options));
 
     var blockquoteText = '> Blockquote';
-    equal(marked(blockquoteText, { renderer: r }), '    Blockquote\n\n');
+    equal(marked(blockquoteText), '    Blockquote\n\n');
 
     var listText = '* List Item';
-    equal(marked(listText, { renderer: r }), '    * List Item\n\n');
+    equal(marked(listText), '    * List Item\n\n');
   });
 
   it('should use default tabs if passing not supported string', function () {
     var options = Object.assign({}, defaultOptions, { tab: 'dsakdskajhdsa' });
-    var r = new Renderer(options);
+    marked.use(markedTerminal(options));
 
     var blockquoteText = '> Blockquote';
-    equal(marked(blockquoteText, { renderer: r }), '    Blockquote\n\n');
+    equal(marked(blockquoteText), '    Blockquote\n\n');
 
     var listText = '* List Item';
-    equal(marked(listText, { renderer: r }), '    * List Item\n\n');
+    equal(marked(listText), '    * List Item\n\n');
   });
 
   it('should change tabs by allowed characters', function () {
     var options = Object.assign({}, defaultOptions, { tab: '\t' });
-    var r = new Renderer(options);
+    marked.use(markedTerminal(options));
 
     var blockquoteText = '> Blockquote';
-    equal(marked(blockquoteText, { renderer: r }), '\tBlockquote\n\n');
+    equal(marked(blockquoteText), '\tBlockquote\n\n');
 
     var listText = '* List Item';
-    equal(marked(listText, { renderer: r }), '\t* List Item\n\n');
+    equal(marked(listText), '\t* List Item\n\n');
   });
 
   it('should support mulitple tab characters', function () {
     var options = Object.assign({}, defaultOptions, { tab: '\t\t' });
-    var r = new Renderer(options);
+    marked.use(markedTerminal(options));
 
     var blockquoteText = '> Blockquote';
-    equal(marked(blockquoteText, { renderer: r }), '\t\tBlockquote\n\n');
+    equal(marked(blockquoteText), '\t\tBlockquote\n\n');
 
     var listText = '* List Item';
-    equal(marked(listText, { renderer: r }), '\t\t* List Item\n\n');
+    equal(marked(listText), '\t\t* List Item\n\n');
   });
 
   it('should support overriding image handling', function () {
@@ -99,13 +96,13 @@ describe('Options', function () {
         return 'IMAGE';
       }
     });
-    var r = new Renderer(options);
+    marked.use(markedTerminal(options));
 
     var text = `
 # Title
 ![Alt text](./img.jpg)`;
     equal(
-      marked(text, { renderer: r }),
+      marked(text),
       `# Title
 
 IMAGE

--- a/tests/markedTerminal-options.js
+++ b/tests/markedTerminal-options.js
@@ -1,6 +1,6 @@
 import { notEqual, equal } from 'assert';
 import { markedTerminal } from '../index.js';
-import marked from './_marked.js';
+import marked, { resetMarked } from './_marked.js';
 
 var identity = function (o) {
   return o;
@@ -33,7 +33,7 @@ defaultOptions.emoji = false;
 
 describe('Options', function () {
   beforeEach(function () {
-    marked.setOptions(marked.getDefaults());
+    resetMarked();
   });
 
   it('should not translate emojis', function () {

--- a/tests/markedTerminal-usage.js
+++ b/tests/markedTerminal-usage.js
@@ -1,5 +1,5 @@
 import { equal, notEqual } from 'assert';
-import Renderer from '../index.js';
+import { markedTerminal } from '../index.js';
 import marked from './_marked.js';
 
 let identity = function (o) {
@@ -46,31 +46,27 @@ defaultOptions.tableOptions = {
 };
 
 function markup(str, gfm = false) {
-  let r = new Renderer(defaultOptions2);
-  let markedOptions = {
-    renderer: r,
-    gfm: gfm
-  };
-  return stripTermEsc(marked(str, markedOptions));
+  marked.use(
+    markedTerminal(defaultOptions2),
+    { gfm }
+  )
+  return stripTermEsc(marked(str));
 }
 
 describe('Renderer', function () {
-  let r = new Renderer(defaultOptions);
-  let markedOptions = {
-    renderer: r
-  };
-
   beforeEach(function () {
     marked.setOptions(marked.getDefaults());
   });
 
   it('should render links', function () {
+    marked.use(markedTerminal(defaultOptions));
     let text = '[Google](http://google.com)';
     let expected = 'Google (http://google.com)';
-    equal(marked(text, markedOptions).trim(), expected);
+    equal(marked(text).trim(), expected);
   });
 
   it('should pass on options to table', function () {
+    marked.use(markedTerminal(defaultOptions));
     let text =
       '| Lorem | Ipsum | Sit amet     | Dolar  |\n' +
       '|------|------|----------|----------|\n' +
@@ -79,20 +75,23 @@ describe('Renderer', function () {
       '| Row 3  | Value    | Value  | Value |\n' +
       '| Row 4  | Value    | Value  | Value |';
 
-    notEqual(marked(text, markedOptions).indexOf('@@@@TABLE@@@@@'), -1);
+    notEqual(marked(text).indexOf('@@@@TABLE@@@@@'), -1);
   });
 
   it('should not show link href twice if link and url is equal', function () {
+    marked.use(markedTerminal(defaultOptions));
     let text = 'http://google.com';
-    equal(marked(text, markedOptions).trim(), text);
+    equal(marked(text).trim(), text);
   });
 
   it('should render html as html', function () {
+    marked.use(markedTerminal(defaultOptions));
     let html = '<strong>foo</strong>';
-    equal(marked(html, markedOptions).trim(), html);
+    equal(marked(html).trim(), html);
   });
 
   it('should not escape entities', function () {
+    marked.use(markedTerminal(defaultOptions));
     let text =
       '# This < is "foo". it\'s a & string\n' +
       '> This < is "foo". it\'s a & string\n\n' +
@@ -104,29 +103,33 @@ describe('Renderer', function () {
       '    This < is "foo". it\'s a & string\n\n' +
       'This < is "foo". it\'s a & string\n' +
       'This < is "foo". it\'s a & string';
-    equal(marked(text, markedOptions).trim(), expected);
+    equal(marked(text).trim(), expected);
   });
 
   it('should not translate emojis inside codespans', function () {
+    marked.use(markedTerminal(defaultOptions));
     let markdownText = 'Some `:+1:`';
 
-    notEqual(marked(markdownText, markedOptions).indexOf(':+1:'), -1);
+    notEqual(marked(markdownText).indexOf(':+1:'), -1);
   });
 
   it('should translate emojis', function () {
+    marked.use(markedTerminal(defaultOptions));
     let markdownText = 'Some :+1:';
-    equal(marked(markdownText, markedOptions).indexOf(':+1'), -1);
+    equal(marked(markdownText).indexOf(':+1'), -1);
   });
 
   it('should show default if not supported emojis', function () {
+    marked.use(markedTerminal(defaultOptions));
     let markdownText = 'Some :someundefined:';
     notEqual(
-      marked(markdownText, markedOptions).indexOf(':someundefined:'),
+      marked(markdownText).indexOf(':someundefined:'),
       -1
     );
   });
 
   it('should not escape entities', function () {
+    marked.use(markedTerminal(defaultOptions));
     let markdownText =
       'Usage | Syntax' +
       '\r\n' +
@@ -134,7 +137,7 @@ describe('Renderer', function () {
       '\r\n' +
       'General |`$ shell <CommandParam>`';
 
-    notEqual(marked(markdownText, markedOptions).indexOf('<CommandParam>'), -1);
+    notEqual(marked(markdownText).indexOf('<CommandParam>'), -1);
   });
 
   it('should reflow paragraph and split words that are too long (one break)', function () {

--- a/tests/markedTerminal-usage.js
+++ b/tests/markedTerminal-usage.js
@@ -1,6 +1,6 @@
 import { equal, notEqual } from 'assert';
 import { markedTerminal } from '../index.js';
-import marked from './_marked.js';
+import marked, { resetMarked } from './_marked.js';
 
 let identity = function (o) {
   return o;
@@ -55,7 +55,7 @@ function markup(str, gfm = false) {
 
 describe('Renderer', function () {
   beforeEach(function () {
-    marked.setOptions(marked.getDefaults());
+    resetMarked();
   });
 
   it('should render links', function () {

--- a/tests/options.js
+++ b/tests/options.js
@@ -1,6 +1,6 @@
 import { notEqual, equal } from 'assert';
 import Renderer from '../index.js';
-import marked from './_marked.js';
+import marked, { resetMarked } from './_marked.js';
 
 var identity = function (o) {
   return o;
@@ -35,7 +35,7 @@ describe('Options', function () {
   var r = new Renderer(defaultOptions);
 
   beforeEach(function () {
-    marked.setOptions(marked.getDefaults());
+    resetMarked();
   });
 
   it('should not translate emojis', function () {

--- a/tests/usage.js
+++ b/tests/usage.js
@@ -1,6 +1,6 @@
 import { equal, notEqual } from 'assert';
 import Renderer from '../index.js';
-import marked from './_marked.js';
+import marked, { resetMarked } from './_marked.js';
 
 let identity = function (o) {
   return o;
@@ -61,7 +61,7 @@ describe('Renderer', function () {
   };
 
   beforeEach(function () {
-    marked.setOptions(marked.getDefaults());
+    resetMarked();
   });
 
   it('should render links', function () {


### PR DESCRIPTION
This exports a function that can be used with `marked.use`.

`marked.use` allows multiple extensions to be used without completely overwriting each other. 

This also leaves the current default `Renderer` so there are no breaking changes.

### Usage

```js
import { marked } from 'marked';
import { markedTerminal } from 'marked-terminal';

marked.use(markedTerminal([options][, highlightOptions]));

marked.parse(markdown);
```