### PR TITLE
Use a more robust ANSI regex for text length calculation

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,7 +326,9 @@ Renderer.prototype.link = function (href, title, text) {
     } else {
       link = this.o.href(href);
     }
-    out = ansiEscapes.link(link, href);
+    out = ansiEscapes.link(link, href
+      // textLength breaks on '+' in URLs
+      .replace(/\+/g, '%20'));
   } else {
     if (hasText) out += this.emoji(text) + ' (';
     out += this.o.href(href);

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import { highlight as highlightCli } from 'cli-highlight';
 import * as emoji from 'node-emoji';
 import ansiEscapes from 'ansi-escapes';
 import supportsHyperlinks from 'supports-hyperlinks';
+import ansiRegex from 'ansi-regex';
 
 var TABLE_CELL_SPLIT = '^*||*^';
 var TABLE_ROW_WRAP = '*|*|*|*';
@@ -15,6 +16,8 @@ var COLON_REPLACER = '*#COLON|*';
 var COLON_REPLACER_REGEXP = new RegExp(escapeRegExp(COLON_REPLACER), 'g');
 
 var TAB_ALLOWED_CHARACTERS = ['\t'];
+
+var ANSI_REGEXP = ansiRegex();
 
 // HARD_RETURN holds a character sequence used to indicate text has a
 // hard (no-reflowing) line break.  Previously \r and \r\n were turned
@@ -65,7 +68,7 @@ function Renderer(options, highlightOptions) {
 // Compute length of str not including ANSI escape codes.
 // See http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
 function textLength(str) {
-  return str.replace(/\u001b\[(?:\d{1,3})(?:;\d{1,3})*m/g, '').length;
+  return str.replace(ANSI_REGEXP, '').length;
 }
 
 Renderer.prototype.textLength = textLength;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.0.1",
         "chalk": "^5.3.0",
         "cli-highlight": "^2.1.11",
         "cli-table3": "^0.6.5",
@@ -55,18 +56,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
@@ -516,11 +505,14 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -1693,6 +1685,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -1925,12 +1934,6 @@
         "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
@@ -2196,9 +2199,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -3035,6 +3038,13 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
         "ansi-regex": "^5.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        }
       }
     },
     "strip-ansi-cjs": {
@@ -3044,6 +3054,14 @@
       "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        }
       }
     },
     "strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^7.0.0",
+    "ansi-regex": "^6.0.1",
     "chalk": "^5.3.0",
     "cli-highlight": "^2.1.11",
     "cli-table3": "^0.6.5",


### PR DESCRIPTION
This fixes an issue where links inside list items rendered poorly.

Note that the new dependency (`ansi-regex` is tiny and also MIT-licensed)

### Example markdown

```md
Here are some space opera recommendations focused on exploring the galaxy and different cultures within it: 

1.  **[The Long Way to a Small, Angry Planet](https://play.google.com/store/books/details?id=dgFxCQAAQBAJ&source=gbs_api)** 
    ![The Long Way to a Small, Angry Planet](http://books.google.com/books/content?id=dgFxCQAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api)
    This book is a feel-good space opera that follows a crew on a spaceship as they build a hyperspace tunnel to a distant planet. It's full of interesting alien characters and touches on themes of identity, friendship, and belonging.

2.  **[Look to Windward](https://play.google.com/store/books/details?id=HovpJmfv4wAC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api)** 
    ![Look to Windward](http://books.google.com/books/content?id=HovpJmfv4wAC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api)
    This book is part of Iain M. Banks' Culture series, which is known for its focus on advanced technology and utopian societies. This book focuses on the Culture's interactions with other cultures and the potential conflicts that arise from their differing views. 
```

### Before this PR:

<img width="816" alt="Before" src="https://github.com/user-attachments/assets/9997df0d-4998-4f43-888f-7f9343ac4b97">

### After this PR:

<img width="804" alt="image" src="https://github.com/user-attachments/assets/fde5c89e-6038-41b3-bb68-6924af5ef6c8">
