### PR TITLE
Auto-update dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,22 @@ jobs:
         run: npm install --no-save marked@${{ matrix.marked-version }}
       - name: Run unittests
         run: npm test
+
+  auto-merge:
+    needs: 
+      - marked-compatibility
+      - node-compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: auto-merge
+        if: |
+          github.actor == 'dependabot[bot]' &&
+          github.event_name == 'pull_request'
+        run: |
+          ./merge_dependabot.sh
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          # this secret needs to be in the settings.secrets.dependabot
+          GITHUB_TOKEN: ${{secrets.GH_ACTION_TOKEN}}


### PR DESCRIPTION
You'll need to check your settings to give dependabot permission to do a pull request.
I think I needed to make an GH_ACTION_TOKEN as well.

But this will auto-accept dependbot pull requests if they pass all the tests. it's super useful.


