### PR TITLE
fix: enable inline parsing of content with marked v13+

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ Renderer.prototype.space = function () {
 
 Renderer.prototype.text = function (text) {
   if (typeof text === 'object') {
-    text = text.text;
+    text = text.tokens ? this.parser.parseInline(text.tokens) : text.text;
   }
   return this.o.text(text);
 };


### PR DESCRIPTION
fixes #304
