### PR TITLE
feat: support enable/disable hyper link by `forceHyperLink` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ var defaultOptions = {
   tab: 3 // examples: 4, 2, \t, \t\t
 
   image: function (href, title, text) {} // function for overriding the default image handling.
+
+  // Boolean, force enable or disable hyper link, default is `undefined`
+  // If undefined, it will dynamically determine whether the current environment supports hyperlink
+  forceHyperLink: undefined
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ var defaultOptions = {
   showSectionPrefix: true,
   reflowText: false,
   tab: 4,
-  tableOptions: {}
+  tableOptions: {},
+  forceHyperLink: undefined
 };
 
 function Renderer(options, highlightOptions) {
@@ -323,7 +324,12 @@ Renderer.prototype.link = function (href, title, text) {
 
   var out = '';
 
-  if (supportsHyperlinks.stdout) {
+  const { forceHyperLink } = this.o;
+
+  if (
+    forceHyperLink === true ||
+    (forceHyperLink !== false && supportsHyperlinks.stdout)
+  ) {
     let link = '';
     if (text) {
       link = this.o.href(this.emoji(text));

--- a/tests/options.js
+++ b/tests/options.js
@@ -1,6 +1,7 @@
 import { notEqual, equal } from 'assert';
 import Renderer from '../index.js';
 import marked, { resetMarked } from './_marked.js';
+import ansiEscapes from 'ansi-escapes';
 
 var identity = function (o) {
   return o;
@@ -82,7 +83,7 @@ describe('Options', function () {
     equal(marked(listText, { renderer: r }), '\t* List Item\n\n');
   });
 
-  it('should support mulitple tab characters', function () {
+  it('should support multiple tab characters', function () {
     var options = Object.assign({}, defaultOptions, { tab: '\t\t' });
     var r = new Renderer(options);
 
@@ -109,6 +110,48 @@ describe('Options', function () {
       `# Title
 
 IMAGE
+
+`
+    );
+  });
+
+  it('should support disable hyper link by set forceHyperLink to false', function () {
+    var options = Object.assign({}, defaultOptions, {
+      forceHyperLink: false
+    });
+    var r = new Renderer(options);
+
+    var text = `
+# Title
+
+[Github](https://www.github.com)
+`;
+    equal(
+      marked(text, { renderer: r }),
+      `# Title
+
+Github (https://www.github.com)
+
+`
+    );
+  });
+
+  it('should support enable hyper link by set forceHyperLink to true', function () {
+    var options = Object.assign({}, defaultOptions, {
+      forceHyperLink: true
+    });
+    var r = new Renderer(options);
+
+    var text = `
+  # Title
+
+[Github](https://www.github.com)
+  `;
+    equal(
+      marked(text, { renderer: r }),
+      `# Title
+
+${ansiEscapes.link('Github', 'https://www.github.com')}${'\n  '}
 
 `
     );


### PR DESCRIPTION
I need to diable hyper link but I can not use env `FORCE_HYPERLINK=0`, so I added an option `forceHyperLink` for marked-terminal


```javascript
var defaultOptions = {
  // Boolean, force enable or disable hyper link, default is `undefined`
  // If undefined, it will dynamically determine whether the current environment supports hyperlink
  forceHyperLink: undefined
};
```