### PR TITLE
Render inline styles in list items

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,18 @@ Renderer.prototype.listitem = function (text) {
       }
     }
 
-    text += this.parser.parse(item.tokens, !!item.loose);
+    // Process list item tokens correctly
+    // List items can contain both block and inline content
+    for (let i = 0; i < item.tokens.length; i++) {
+      const token = item.tokens[i];
+      if (token.type === 'text' && token.tokens) {
+        // This is inline content with formatting, use parseInline
+        text += this.parser.parseInline(token.tokens);
+      } else {
+        // This is block content or plain text, use parse
+        text += this.parser.parse([token], !!item.loose);
+      }
+    }
   }
   var transform = compose(this.o.listitem, this.transform);
   var isNested = text.indexOf('\n') !== -1;

--- a/tests/inline-formatting.js
+++ b/tests/inline-formatting.js
@@ -1,0 +1,98 @@
+import { equal } from 'assert';
+import { markedTerminal } from '../index.js';
+import marked, { resetMarked } from './_marked.js';
+
+var identity = function (o) {
+  return o;
+};
+
+function stripTermEsc(str) {
+  return str.replace(/\u001b\[\d{1,2}m/g, '');
+}
+
+var debugOptions = {
+  strong: (text) => `[STRONG:${text}]`,
+  em: (text) => `[EM:${text}]`,
+  codespan: (text) => `[CODE:${text}]`,
+  del: (text) => `[DEL:${text}]`,
+  listitem: identity
+};
+
+function markupWithDebug(str) {
+  marked.use(markedTerminal(debugOptions));
+  return stripTermEsc(marked(str));
+}
+
+describe('Inline Formatting in Lists', function () {
+  beforeEach(function () {
+    resetMarked();
+  });
+
+  it('should render bold text in list items', function () {
+    const markdown = '1. **bold text** in list';
+    const actual = markupWithDebug(markdown);
+    const expected = '    1. [STRONG:bold text] in list\n\n';
+    equal(actual, expected);
+  });
+
+  it('should render italic text in list items', function () {
+    const markdown = '* _italic text_ in list';
+    const actual = markupWithDebug(markdown);
+    const expected = '    * [EM:italic text] in list\n\n';
+    equal(actual, expected);
+  });
+
+  it('should render mixed formatting in list items', function () {
+    const markdown = '1. **bold** and _italic_ text';
+    const actual = markupWithDebug(markdown);
+    const expected = '    1. [STRONG:bold] and [EM:italic] text\n\n';
+    equal(actual, expected);
+  });
+
+  it('should render code spans in list items', function () {
+    const markdown = '* `code` in list';
+    const actual = markupWithDebug(markdown);
+    const expected = '    * [CODE:code] in list\n\n';
+    equal(actual, expected);
+  });
+
+  it('should render strikethrough in list items', function () {
+    const markdown = '- ~~deleted text~~ in list';
+    const actual = markupWithDebug(markdown);
+    const expected = '    * [DEL:deleted text] in list\n\n';
+    equal(actual, expected);
+  });
+
+  it('should render complex inline formatting in list items', function () {
+    const markdown = '1. **bold** _italic_ `code` ~~strike~~';
+    const actual = markupWithDebug(markdown);
+    const expected = '    1. [STRONG:bold] [EM:italic] [CODE:code] [DEL:strike]\n\n';
+    equal(actual, expected);
+  });
+
+  it('should render inline formatting in multiple list items', function () {
+    const markdown = `1. **first** item
+2. _second_ item
+3. \`third\` item`;
+    const actual = markupWithDebug(markdown);
+    const expected = '    1. [STRONG:first] item\n    2. [EM:second] item\n    3. [CODE:third] item\n\n';
+    equal(actual, expected);
+  });
+
+  it('should render inline formatting in unordered lists', function () {
+    const markdown = `* **bold** item
+* _italic_ item
+* \`code\` item`;
+    const actual = markupWithDebug(markdown);
+    const expected = '    * [STRONG:bold] item\n    * [EM:italic] item\n    * [CODE:code] item\n\n';
+    equal(actual, expected);
+  });
+
+  it('should preserve existing functionality for plain text lists', function () {
+    const markdown = `1. plain text
+2. more plain text`;
+    const actual = markupWithDebug(markdown);
+    const expected = '    1. plain text\n    2. more plain text\n\n';
+    equal(actual, expected);
+  });
+});


### PR DESCRIPTION
## Description

Fixes https://github.com/mikaelbr/marked-terminal/issues/371

#### Before

<img width="713" height="141" alt="image" src="https://github.com/user-attachments/assets/7e0c101b-e4ff-4c0f-bd1b-9d445c388fd3" />

#### After

<img width="689" height="138" alt="image" src="https://github.com/user-attachments/assets/722cc412-f0ee-4ec3-ba7c-74f1935f4e46" />

### Reviewer Notes

I _believe_ this is a reasonable implementation leaning on `parseInline` when there is just text but I'll be honest and say I was surprised that `parse` didn't work by itself (I expected it would figure out that it needed to `parseInline). In any case, it appears to solve my issue. Feel free to change the PR in whatever way you see fit, I'm not attached to any of it.

Thanks for the library!
