### PR TITLE
chore: replace ansiEscapes.link with inlined code

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 import { highlight as highlightCli } from 'cli-highlight';
 import * as emoji from 'node-emoji';
-import ansiEscapes from 'ansi-escapes';
 import supportsHyperlinks from 'supports-hyperlinks';
 import ansiRegex from 'ansi-regex';
 
@@ -330,12 +329,8 @@ Renderer.prototype.link = function (href, title, text) {
     } else {
       link = this.o.href(href);
     }
-    out = ansiEscapes.link(
-      link,
-      href
-        // textLength breaks on '+' in URLs
-        .replace(/\+/g, '%20')
-    );
+    // textLength breaks on '+' in URLs
+    out = `\u001B]8;;${href.replace(/\+/g, '%20')}\u0007${link}\u001B]8;;\u0007`;
   } else {
     if (hasText) out += this.emoji(text) + ' (';
     out += this.o.href(href);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "7.3.0",
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^7.0.0",
         "ansi-regex": "^6.1.0",
         "chalk": "^5.4.1",
         "cli-highlight": "^2.1.11",
@@ -504,20 +503,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
-      "dependencies": {
-        "environment": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -835,17 +820,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
-    },
-    "node_modules/environment": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -2207,14 +2181,6 @@
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true
     },
-    "ansi-escapes": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
-      "requires": {
-        "environment": "^1.0.0"
-      }
-    },
     "ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -2445,11 +2411,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
-    },
-    "environment": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="
     },
     "escalade": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "marked": ">=1 <17"
   },
   "dependencies": {
-    "ansi-escapes": "^7.0.0",
     "ansi-regex": "^6.1.0",
     "chalk": "^5.4.1",
     "cli-highlight": "^2.1.11",


### PR DESCRIPTION
We only use one method from `ansi-escapes`, the method is `.link`. So, for reducing install size, we can inline this method.
